### PR TITLE
feat: add ava unit testing snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Snippets4Dummies is an easy to use Visual Code Extension which is used for build
 - Basic nextjs middleware route generator.
 - Basic react component generator.
 - Basic react component generator(in typescript).
+- Basic ava unit testing snippets.
 
 ## How to use?
 
@@ -17,6 +18,7 @@ Snippets4Dummies is an easy to use Visual Code Extension which is used for build
 - `!nextmid` command to generate basic nextjs middleware route.
 - `!reactjs` command to generate basic react component.
 - `!reactts` command to generate basic react component in typescript.
+- All snippets starting with `!ava` command to generate ava unit testing snippets.
 
 ## Requirements
 

--- a/snippets/snippets-ava.json
+++ b/snippets/snippets-ava.json
@@ -1,0 +1,73 @@
+{
+  "Generates basic ava test": {
+    "prefix": "!avatest",
+    "body": ["test('test name', t => {", "    t.pass();", "});"],
+    "description": "Generates basic ava test"
+  },
+  "Generates truthy type ava test": {
+    "prefix": "!avatruthy",
+    "body": [
+      "test('test is truthy', t => {",
+      "    t.truthy('truthy test goes here');",
+      "});"
+    ],
+    "description": "Generates truthy type ava test"
+  },
+  "Generates falsy type ava test": {
+    "prefix": "!avafalsy",
+    "body": [
+      "test('test is falsy', t => {",
+      "    t.falsy('falsy type test goes here');",
+      "});"
+    ],
+    "description": "Generates falsy type ava test"
+  },
+  "Generates is type ava test": {
+    "prefix": "!avais",
+    "body": [
+      "test('test is', t => {",
+      "    t.is('actual', 'expected');",
+      "});"
+    ],
+    "description": "Generates is type ava test"
+  },
+  "Generates not type ava test": {
+    "prefix": "!avanot",
+    "body": [
+      "test('test not', t => {",
+      "    t.not('actual', 'expected');",
+      "});"
+    ],
+    "description": "Generates not type ava test"
+  },
+  "Generates deep equal type ava test": {
+    "prefix": "!avadeepeq",
+    "body": [
+      "test('test deep equal', t => {",
+      "    t.deepEqual('actual', 'expected');",
+      "});"
+    ],
+    "description": "Generates deep equal type ava test"
+  },
+  "Generates not deep equal type ava test": {
+    "prefix": "!avanotdeepeq",
+    "body": [
+      "test('test not deep equal', t => {",
+      "    t.notDeepEqual('actual', 'expected');",
+      "});"
+    ],
+    "description": "Generates not deep equal type ava test"
+  },
+  "Generates function throws type ava test": {
+    "prefix": "!avathrows",
+    "body": [
+      "test('test function throws', t => {",
+      "    const error = t.throws(() => {",
+      "        functionName();",
+      "    }, {instanceOf: TypeError});",
+      "    t.is(error.message, 'Error message');",
+      "});"
+    ],
+    "description": "Generates function throws type ava test"
+  }
+}


### PR DESCRIPTION
Hello there 👋

I've added a few snippets related to Unit Testing using the [Ava](https://github.com/avajs/ava) test runner framework

Why? Because I believe unit testing is a super-important part of your code and helps you to figure and _assert_ whether your code works as expected. Also, I used Ava because it seems to be what people prefer to use nowadays and is in use across thousands of NodeJS projects. In case you wish to check why Ava is a better alternative, please read [this](https://github.com/avajs/ava#why-not-mocha-tape-tap).

Cheers,
Skyascii